### PR TITLE
Fix broken stats reporting

### DIFF
--- a/src/TestimonySource.cc
+++ b/src/TestimonySource.cc
@@ -105,10 +105,10 @@ bool TestimonySource::ExtractNextPacket(Packet* pkt)
 				Error("empty packet header");
 				return false;
 			}
-			return true;
 			
 			++stats.received;
 			stats.bytes_received += packet->tp_len;
+			return true;
 		}
 		
 		


### PR DESCRIPTION
Since the function was returning before setting the stats, pkts_proc and bytes_recv are always 0. Moving the return to after setting the stats results in the values being shown in stats.log