### PR TITLE
Set testimony_get_block timeout to 1000ms

### DIFF
--- a/src/TestimonySource.cc
+++ b/src/TestimonySource.cc
@@ -77,7 +77,7 @@ bool TestimonySource::ExtractNextPacket(Packet* pkt)
 
 		if ( (packet = testimony_iter_next(td_iter)) == NULL ) {
 			testimony_return_block(td, block);
-			int res = testimony_get_block(td, 0, &block);
+			int res = testimony_get_block(td, 1000, &block);
 			if ( res == 0 && !block ) {
 				// Timeout
 				continue;


### PR DESCRIPTION
With no timeout, the while loop causes high strain on the CPU by flooding it with poll syscalls. I set it to 1000ms since Clerk and Stenographer use the same function and set the timeout to 1000ms. In my testing, the timeout fixed CPU usage and had no noticeable affect elsewhere.

This could also be added by way of an optional parameter if desired, but none of the other examples I've seen deviate from the 1000ms timeout.